### PR TITLE
Don't use osso service activation

### DIFF
--- a/etc/osso-xterm.desktop.in
+++ b/etc/osso-xterm.desktop.in
@@ -9,5 +9,4 @@ Terminal=false
 Type=Application
 Categories=System;TerminalEmulator;
 X-HildonDesk-ShowInToolbar=true
-X-Osso-Service=xterm
 X-Osso-Type=application/x-executable


### PR DESCRIPTION
This avoids a bug where hildon will fail to launch a xterm when another application with terminal=true is running, instead activating the terminal application via dbus and then failing to switch to the window because the hd-running-apps dont align